### PR TITLE
Update download plugin to be compatible with gradle 2.7+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
-plugins
-{ id "de.undercouch.download" version "1.2" }
+plugins {
+  id "de.undercouch.download" version "2.0.0"
+}
 
 apply from: 'dependencies.gradle'
 apply plugin: 'java'
@@ -12,6 +13,7 @@ checkstyle {
 group = 'org.openstreetmap.josm.plugins'
 version = '0.0.0-SNAPSHOT'
 
+// Change JOSM version (if needed) before you build
 project.ext.josm_version='8599'
 project.ext.josm_location='download'
 //project.ext.josm_location='download/Archiv'
@@ -58,7 +60,6 @@ jar
         )
     }
 }
-
 
 import de.undercouch.gradle.tasks.download.Download
 


### PR DESCRIPTION
@matthieun : I ran into an issue with download task because of version compatibility issue. 
